### PR TITLE
fix: update authorization header format and bump version to 1.0.7

### DIFF
--- a/credentials/ToolhouseApi.credentials.ts
+++ b/credentials/ToolhouseApi.credentials.ts
@@ -29,7 +29,7 @@ export class ToolhouseApi implements ICredentialType {
     type: "generic",
     properties: {
       headers: {
-        Authorization: "Bearer {{$credentials.token}}",
+        Authorization: "=Bearer {{$credentials.token}}",
       },
     },
   };
@@ -40,7 +40,7 @@ export class ToolhouseApi implements ICredentialType {
       url: "v1/agents",
       method: "GET",
       headers: {
-        Authorization: "Bearer {{$credentials.token}}",
+        Authorization: "=Bearer {{$credentials.token}}",
       },
     },
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@toolhouseai/n8n-nodes-toolhouse",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@toolhouseai/n8n-nodes-toolhouse",
-      "version": "1.0.5",
+      "version": "1.0.7",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^14.14.37",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toolhouseai/n8n-nodes-toolhouse",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "main": "index.js",
   "scripts": {
     "build": "npx rimraf dist && tsc && npm run copy:icons",


### PR DESCRIPTION
This PR should address the issue that was preventing the token from being sent correctly through n8n to the Toolhouse API backend by adding a formula escape character on the credentials field